### PR TITLE
fix: upgrade actions to versions supporting Node 24

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,18 +29,18 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 10
           fetch-tags: true
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.21.0'
       - name: Tag
         uses: martoc/action-tag@v0
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: github-actions
@@ -71,7 +71,7 @@ jobs:
         run: |
           set | grep TAG_ > shared-envars.sh
           cat shared-envars.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: shared-envars
           path: shared-envars.sh
@@ -83,7 +83,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: shared-envars
           path: .
@@ -93,9 +93,9 @@ jobs:
           cat shared-envars.sh
           source shared-envars.sh
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Checkout Cloudformation Template
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: martoc/cloudformation-${{ inputs.workload-type }}
           path: ./cloudformation-template
@@ -110,7 +110,7 @@ jobs:
           fi
           cat cloudformation-template/src/cloudformation/main.yaml
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: github-actions

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -29,18 +29,18 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 10
           fetch-tags: true
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
       - name: Tag
         uses: martoc/action-tag@v0
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: github-actions
@@ -60,7 +60,7 @@ jobs:
         run: |
           set | grep TAG_ > shared-envars.sh
           cat shared-envars.sh
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: shared-envars
           path: shared-envars.sh
@@ -71,7 +71,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: shared-envars
           path: .
@@ -81,9 +81,9 @@ jobs:
           cat shared-envars.sh
           source shared-envars.sh
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Checkout Cloudformation Template
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: martoc/cloudformation-${{ inputs.workload-type }}
           path: ./cloudformation-template
@@ -98,7 +98,7 @@ jobs:
           fi
           cat cloudformation-template/src/cloudformation/main.yaml
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@v4
+        uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-session-name: github-actions


### PR DESCRIPTION
## Summary

- Bump `actions/checkout` v4 → v6 in `.github/workflows/{go,node}.yml`
- Bump `aws-actions/configure-aws-credentials` v4 → v6 in `.github/workflows/{go,node}.yml`
- Bump `actions/upload-artifact` v4 → v7 and `actions/download-artifact` v4 → v8 in both workflows
- Bump `actions/setup-go` v5 → v6 in `go.yml`
- Bump `actions/setup-node` v4 → v6 in `node.yml`

## Why

GitHub Actions has deprecated Node.js 20 (see [deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). From 2 June 2026, affected actions will be forced onto Node.js 24; Node.js 20 is removed from the runner on 16 September 2026. The bumped versions run on Node.js 24 by default.

## Test plan

- [ ] CI checks pass
- [ ] Reusable workflow callers (Go & Node workloads) continue to build, test and deploy successfully
